### PR TITLE
Fix loading boolean state

### DIFF
--- a/Frontend/src/components/PokemonProvider/PokemonProvider.js
+++ b/Frontend/src/components/PokemonProvider/PokemonProvider.js
@@ -5,8 +5,13 @@ export const PokemonContext = createContext();
 
 const PokemonProvider = pokemon => {
   const [cards, setCards] = useState([]);
-  const [finalPage, setFinalPage] = useState([]);
-  const [loading, setLoading] = useState([false]);
+  // finalPage stores the last page number returned from the API. 0 means
+  // that we haven't loaded any pages yet.
+  const [finalPage, setFinalPage] = useState(0);
+
+  // loading indicates if the pokemon list is currently being fetched. It
+  // should be a boolean value rather than an array containing a boolean.
+  const [loading, setLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [searchQuery, setSearchQuery] = useState('');
   const [showHeaderArrows, setShowHeaderArrows] = useState(true);


### PR DESCRIPTION
## Summary
- fix default loading state to use boolean instead of array
- initialize final page as numeric value

## Testing
- `yarn test --watchAll=false` *(fails: 7 snapshots failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840ef5aaa048325a08380d001457dac