### PR TITLE
Refactor React components for clarity and performance

### DIFF
--- a/Frontend/src/components/AuthContext/AuthContext.js
+++ b/Frontend/src/components/AuthContext/AuthContext.js
@@ -15,27 +15,27 @@ export const AuthProvider = props => {
     handleTokenChange(token);
   }, [token]);
 
-  function onLogin(newToken) {
+  const onLogin = React.useCallback(newToken => {
     localStorage.setItem('auth_token', newToken);
     setToken(newToken);
-  }
+  }, []);
 
-  function onLogout() {
+  const onLogout = React.useCallback(() => {
     localStorage.removeItem('auth_token');
     setToken(null);
-  }
+  }, []);
 
-  return (
-    <AuthContext.Provider
-      value={{
-        token,
-        isLoggedIn: token ? true : false,
-        login: onLogin,
-        logout: onLogout,
-      }}
-      {...props}
-    />
+  const value = React.useMemo(
+    () => ({
+      token,
+      isLoggedIn: Boolean(token),
+      login: onLogin,
+      logout: onLogout,
+    }),
+    [token, onLogin, onLogout]
   );
+
+  return <AuthContext.Provider value={value} {...props} />;
 };
 
 /**

--- a/Frontend/src/components/Footer/Footer.js
+++ b/Frontend/src/components/Footer/Footer.js
@@ -1,38 +1,43 @@
-import React from 'react';
-import { PokemonContext } from '../PokemonProvider/PokemonProvider';
-import FlexBox from '../FlexBox/FlexBox';
-import Button from '../Button/Button';
+import React, { useCallback, useContext } from 'react';
 import styled from '@emotion/styled';
 import css from '@styled-system/css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
 
+import { PokemonContext } from '../PokemonProvider/PokemonProvider';
+import FlexBox from '../FlexBox/FlexBox';
+import Button from '../Button/Button';
+
+const breakpoints = [1150, 950, 750];
+const mq = breakpoints.map(bp => `@media (max-width: ${bp}px)`);
+
+const FooterContainer = styled(FlexBox)(
+  css({
+    display: 'none',
+    position: 'fixed',
+    bottom: '0',
+    bg: 'leastTransparent',
+    width: '100%',
+    height: '60px',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    [mq[2]]: {
+      display: 'flex',
+    },
+  })
+);
+
 const Footer = () => {
-  const context = React.useContext(PokemonContext);
+  const context = useContext(PokemonContext);
   const leftArrowIcon = <FontAwesomeIcon icon={faArrowLeft} size="2x" />;
   const rightArrowIcon = <FontAwesomeIcon icon={faArrowRight} size="2x" />;
-  const breakpoints = [1150, 950, 750];
-  const mq = breakpoints.map(bp => `@media (max-width: ${bp}px)`);
 
-  const FooterContainer = styled(FlexBox)(
-    css({
-      display: 'none',
-      position: 'fixed',
-      bottom: '0',
-      bg: 'leastTransparent',
-      width: '100%',
-      height: '60px',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      [mq[2]]: {
-        display: 'flex',
-      },
-    })
+  const paginate = useCallback(
+    forwardOrBack => {
+      context.setCurrentPage(forwardOrBack);
+    },
+    [context]
   );
-
-  const paginate = forwardOrBack => {
-    context.setCurrentPage(forwardOrBack);
-  };
 
   return (
     <FooterContainer>
@@ -59,4 +64,4 @@ const Footer = () => {
   );
 };
 
-export default Footer;
+export default React.memo(Footer);

--- a/Frontend/src/components/Header/Header.js
+++ b/Frontend/src/components/Header/Header.js
@@ -1,7 +1,4 @@
-import React from 'react';
-import { PokemonContext } from '../PokemonProvider/PokemonProvider';
-import FlexBox from '../FlexBox/FlexBox';
-import Button from '../Button/Button';
+import React, { useCallback, useContext } from 'react';
 import styled from '@emotion/styled';
 import css from '@styled-system/css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -12,161 +9,167 @@ import {
   faTimesCircle,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { PokemonContext } from '../PokemonProvider/PokemonProvider';
+import FlexBox from '../FlexBox/FlexBox';
+import Button from '../Button/Button';
+
+const breakpoints = [1150, 950, 750];
+const mq = breakpoints.map(bp => `@media (max-width: ${bp}px)`);
+
+const BackButton = styled(Button)(
+  css({
+    borderRadius: 'circle',
+    fontSize: 4,
+    color: 'white',
+    bg: 'lessTransparent',
+    width: '6',
+    height: '6',
+    ml: '5',
+    [mq[2]]: {
+      display: 'none',
+    },
+  })
+);
+
+const ForwardButton = styled(Button)(
+  css({
+    borderRadius: 'circle',
+    fontSize: 4,
+    color: 'white',
+    bg: 'lessTransparent',
+    width: '6',
+    height: '6',
+    mr: '5',
+    [mq[2]]: {
+      display: 'none',
+    },
+  })
+);
+
+const DeleteButton = styled(Button)(
+  css({
+    borderRadius: 'circle',
+    bg: 'transparent',
+    fontSize: '4',
+    width: '5',
+    height: '5',
+    ':hover': css({
+      boxShadow: 'none',
+      transform: 'none',
+    }),
+    [mq[2]]: {
+      fontSize: '2',
+    },
+  })
+);
+
+const SearchBarContainer = styled(FlexBox)(
+  css({
+    alignItems: 'center',
+    height: '96px',
+    minWidth: '480px',
+    bg: 'almostTransparent',
+    borderRadius: '5px',
+    ':hover': css({
+      boxShadow: '0px 0px 10px 0px rgb(0, 0, 0, .75);',
+      transform: 'translate(0px, -1px)',
+    }),
+    [mq[2]]: {
+      minWidth: '250px',
+      height: '6',
+    },
+  })
+);
+
+const SearchBar = styled('input')(
+  css({
+    color: 'white',
+    bg: 'transparent',
+    fontSize: 7,
+    fontWeight: 'bold',
+    height: '96px',
+    width: '400px',
+    border: 'none',
+    outline: 'none',
+    '::placeholder': css({
+      color: 'rgba(0, 0, 0, 0.15)',
+      letterSpacing: '1.5',
+    }),
+    [mq[2]]: {
+      width: '200px',
+      fontSize: 5,
+      height: '5',
+    },
+  })
+);
+
+const SearchIcon = styled(FlexBox)(
+  css({
+    ml: '50px',
+    mr: '30px',
+    fontSize: '5',
+    [mq[2]]: {
+      ml: '20px',
+      mr: '10px',
+      fontSize: '3',
+    },
+  })
+);
+
+const HeaderContainer = styled(FlexBox)(
+  css({
+    width: '100%',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    my: 4,
+    [mq[2]]: {
+      justifyContent: 'center',
+      my: 2,
+    },
+  })
+);
+
 const Header = () => {
-  const context = React.useContext(PokemonContext);
+  const context = useContext(PokemonContext);
   const leftArrowIcon = <FontAwesomeIcon icon={faArrowLeft} />;
   const rightArrowIcon = <FontAwesomeIcon icon={faArrowRight} />;
   const deleteIcon = <FontAwesomeIcon icon={faTimesCircle} color="Gainsboro" />;
   const searchIcon = <FontAwesomeIcon icon={faSearch} color="Snow" />;
 
-  const breakpoints = [1150, 950, 750];
-
-  const mq = breakpoints.map(bp => `@media (max-width: ${bp}px)`);
-
-  const BackButton = styled(Button)(
-    css({
-      borderRadius: 'circle',
-      fontSize: 4,
-      color: 'white',
-      bg: 'lessTransparent',
-      width: '6',
-      height: '6',
-      ml: '5',
-      [mq[2]]: {
-        display: 'none',
-      },
-    })
+  const paginate = useCallback(
+    forwardOrBack => {
+      context.setCurrentPage(forwardOrBack);
+    },
+    [context]
   );
-
-  const ForwardButton = styled(Button)(
-    css({
-      borderRadius: 'circle',
-      fontSize: 4,
-      color: 'white',
-      bg: 'lessTransparent',
-      width: '6',
-      height: '6',
-      mr: '5',
-      [mq[2]]: {
-        display: 'none',
-      },
-    })
-  );
-
-  const DeleteButton = styled(Button)(
-    css({
-      borderRadius: 'circle',
-      bg: 'transparent',
-      fontSize: '4',
-      width: '5',
-      height: '5',
-      ':hover': css({
-        boxShadow: 'none',
-        transform: 'none',
-      }),
-      [mq[2]]: {
-        fontSize: '2',
-      },
-    })
-  );
-
-  const SearchBarContainer = styled(FlexBox)(
-    css({
-      alignItems: 'center',
-      height: '96px',
-      minWidth: '480px',
-      bg: 'almostTransparent',
-      borderRadius: '5px',
-      ':hover': css({
-        boxShadow: '0px 0px 10px 0px rgb(0, 0, 0, .75);',
-        transform: 'translate(0px, -1px)',
-      }),
-      [mq[2]]: {
-        minWidth: '250px',
-        height: '6',
-      },
-    })
-  );
-
-  const SearchBar = styled('input')(
-    css({
-      color: 'white',
-      bg: 'transparent',
-      fontSize: 7,
-      fontWeight: 'bold',
-      height: '96px',
-      width: '400px',
-      border: 'none',
-      outline: 'none',
-      '::placeholder': css({
-        color: 'rgba(0, 0, 0, 0.15)',
-        letterSpacing: '1.5',
-      }),
-      [mq[2]]: {
-        width: '200px',
-        fontSize: 5,
-        height: '5',
-      },
-    })
-  );
-
-  const SearchIcon = styled(FlexBox)(
-    css({
-      ml: '50px',
-      mr: '30px',
-      fontSize: '5',
-      [mq[2]]: {
-        ml: '20px',
-        mr: '10px',
-        fontSize: '3',
-      },
-    })
-  );
-
-  const HeaderContainer = styled(FlexBox)(
-    css({
-      width: '100%',
-      alignItems: 'baseline',
-      justifyContent: 'space-between',
-      my: 4,
-      [mq[2]]: {
-        justifyContent: 'center',
-        my: 2,
-      },
-    })
-  );
-
-  const paginate = forwardOrBack => {
-    context.setCurrentPage(forwardOrBack);
-  };
 
   // Updates the state of search on each keystroke based on the form event of onChange
-  const filterSearch = e => {
-    e.preventDefault();
-    context.setCurrentPage(1);
-    context.setSearchQuery(e.target.value);
-    e.target.value !== ''
-      ? context.setShowDeleteButton(true)
-      : context.setShowDeleteButton(false);
-  };
+  const filterSearch = useCallback(
+    e => {
+      e.preventDefault();
+      context.setCurrentPage(1);
+      context.setSearchQuery(e.target.value);
+      e.target.value !== ''
+        ? context.setShowDeleteButton(true)
+        : context.setShowDeleteButton(false);
+    },
+    [context]
+  );
 
   // Updates the state of search and clears it
-  const clearSearch = () => {
+  const clearSearch = useCallback(() => {
     context.setSearchQuery('');
     context.setCurrentPage(context.currentPage);
     context.setShowDeleteButton(false);
-  };
+  }, [context]);
 
-  function searchPokemonError() {
-    return (
-      context.cards === undefined ||
-      (context.cards.length === 0 && (
-        <FlexBox color="White" fontSize={2} mx={3}>
-          Oops! No pokemon names match your search...
-        </FlexBox>
-      ))
-    );
-  }
+  const searchPokemonError = () =>
+    context.cards === undefined ||
+    (context.cards.length === 0 && (
+      <FlexBox color="White" fontSize={2} mx={3}>
+        Oops! No pokemon names match your search...
+      </FlexBox>
+    ));
 
   return (
     <FlexBox flexDirection="column" alignItems="center">
@@ -207,4 +210,4 @@ const Header = () => {
   );
 };
 
-export default Header;
+export default React.memo(Header);

--- a/Frontend/src/components/PokemonCard/PokemonCard.js
+++ b/Frontend/src/components/PokemonCard/PokemonCard.js
@@ -1,85 +1,86 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
-import FlexBox from '../FlexBox';
-import Box from '../Box';
+import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import css from '@styled-system/css';
 import { keyframes } from '@emotion/core';
+import css from '@styled-system/css';
 import { rubberBand } from 'react-animations';
 
-const PokemonCard = props => {
-  const id = props.id;
-  const name = props.name;
-  const types = props.types;
+import FlexBox from '../FlexBox';
+import Box from '../Box';
 
-  const bounceAnimation = keyframes`${rubberBand}`;
+const bounceAnimation = keyframes`${rubberBand}`;
 
-  const BouncyDiv = styled.div`
-    animation: 1s 0.7s ${bounceAnimation};
-  `;
+const BouncyDiv = styled.div`
+  animation: 1s 0.7s ${bounceAnimation};
+`;
 
-  const Card = styled(FlexBox)(
-    css({
-      borderRadius: 'normal',
-      color: 'darkerGrey',
-      height: '252px',
-      width: '220px',
-      bg: 'white',
-      flexDirection: 'column',
-      justifyContent: 'flex-start',
-      m: 10,
-      ':hover': css({
-        boxShadow: '0px 0px 10px 0px rgb(0, 0, 0, .75);',
-        transform: 'translate(0px, -1px)',
-      }),
-      ':active': css({
-        boxShadow: '0 0px',
-        transform: 'translate(0px, 3px)',
-      }),
-    })
-  );
+const Card = styled(FlexBox)(
+  css({
+    borderRadius: 'normal',
+    color: 'darkerGrey',
+    height: '252px',
+    width: '220px',
+    bg: 'white',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    m: 10,
+    ':hover': css({
+      boxShadow: '0px 0px 10px 0px rgb(0, 0, 0, .75);',
+      transform: 'translate(0px, -1px)',
+    }),
+    ':active': css({
+      boxShadow: '0 0px',
+      transform: 'translate(0px, 3px)',
+    }),
+  })
+);
 
-  const Type = styled(FlexBox)(
-    css({
-      textTransform: 'uppercase',
-      justifyContent: 'center',
-      alignItems: 'center',
-      borderRadius: 'normal',
-      border: '1px solid',
-      marginRight: '10px',
-      fontSize: 0,
-      height: '22px',
-      width: 'auto',
-      padding: '0px 5px',
-    })
-  );
+const Type = styled(FlexBox)(
+  css({
+    textTransform: 'uppercase',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 'normal',
+    border: '1px solid',
+    marginRight: '10px',
+    fontSize: 0,
+    height: '22px',
+    width: 'auto',
+    padding: '0px 5px',
+  })
+);
 
-  return (
-    <Card>
-      <FlexBox my="20px" ml="20px" fontSize={2} fontWeight="bold">
-        {name}
+const PokemonCard = ({ id, name, types }) => (
+  <Card>
+    <FlexBox my="20px" ml="20px" fontSize={2} fontWeight="bold">
+      {name}
+    </FlexBox>
+    <Box mb="20px" borderBottom="1px solid lightGrey" />
+    <BouncyDiv>
+      <FlexBox mb="30px" justifyContent="center">
+        <img src={`/pokemon_images/${id}.png`} alt={name} />
       </FlexBox>
-      <Box mb="20px" borderBottom="1px solid lightGrey"></Box>
-      <BouncyDiv>
-        <FlexBox mb="30px" justifyContent="center">
-          <img src={`/pokemon_images/${id}.png`} alt={name}></img>
-        </FlexBox>
-      </BouncyDiv>
-      <FlexBox justifyContent="flex-end">
-        {types.map((type, index) => (
-          <Type
-            bg={`light${type}`}
-            borderColor={`${type}`}
-            color={`${type}`}
-            fontSize="2"
-            key={id + index}
-          >
-            {type}
-          </Type>
-        ))}
-      </FlexBox>
-    </Card>
-  );
+    </BouncyDiv>
+    <FlexBox justifyContent="flex-end">
+      {types.map((type, index) => (
+        <Type
+          bg={`light${type}`}
+          borderColor={`${type}`}
+          color={`${type}`}
+          fontSize="2"
+          key={id + index}
+        >
+          {type}
+        </Type>
+      ))}
+    </FlexBox>
+  </Card>
+);
+
+PokemonCard.propTypes = {
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  name: PropTypes.string.isRequired,
+  types: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
-export default PokemonCard;
+export default React.memo(PokemonCard);

--- a/Frontend/src/components/PokemonList/PokemonList.js
+++ b/Frontend/src/components/PokemonList/PokemonList.js
@@ -1,15 +1,16 @@
 import React from 'react';
-import PokemonCard from '../PokemonCard/PokemonCard';
 import { Link } from 'react-router-dom';
+
+import PokemonCard from '../PokemonCard/PokemonCard';
 import { PokemonContext } from '../PokemonProvider/PokemonProvider';
 import FlexBox from '../../components/FlexBox';
 
 const PokemonList = () => {
-  const context = React.useContext(PokemonContext);
+  const { cards } = React.useContext(PokemonContext);
 
   return (
     <FlexBox flexWrap="wrap" justifyContent="center" mb="4" mx="3">
-      {context.cards.map((pokemon, index) => (
+      {cards.map((pokemon, index) => (
         <Link
           key={pokemon.id + index}
           to={`/${pokemon.id}`}
@@ -27,4 +28,4 @@ const PokemonList = () => {
   );
 };
 
-export default PokemonList;
+export default React.memo(PokemonList);

--- a/Frontend/src/components/PokemonProvider/PokemonProvider.js
+++ b/Frontend/src/components/PokemonProvider/PokemonProvider.js
@@ -1,9 +1,10 @@
 import React, { createContext, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import axios from 'axios';
 
 export const PokemonContext = createContext();
 
-const PokemonProvider = pokemon => {
+const PokemonProvider = ({ children }) => {
   const [cards, setCards] = useState([]);
   // finalPage stores the last page number returned from the API. 0 means
   // that we haven't loaded any pages yet.
@@ -46,9 +47,13 @@ const PokemonProvider = pokemon => {
         setShowHeaderArrows,
       }}
     >
-      {pokemon.children}
+      {children}
     </PokemonContext.Provider>
   );
+};
+
+PokemonProvider.propTypes = {
+  children: PropTypes.node.isRequired,
 };
 
 export default PokemonProvider;

--- a/Frontend/src/views/PokemonDetail/PokemonDetail.js
+++ b/Frontend/src/views/PokemonDetail/PokemonDetail.js
@@ -1,14 +1,197 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import css from '@styled-system/css';
-import FlexBox from '../../components/FlexBox';
-import Button from '../../components/Button';
-import Axios from 'axios';
 import { Link } from 'react-router-dom';
+import Axios from 'axios';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 
-// eslint-disable-next-line react/prop-types
+import FlexBox from '../../components/FlexBox';
+import Button from '../../components/Button';
+
+const breakpoints = [1150, 950, 850];
+const mq = breakpoints.map(bp => `@media (max-width: ${bp}px)`);
+
+const DetailContainer = styled(FlexBox)(
+  css({
+    bg: 'green',
+    height: '100vh',
+    width: '65%',
+    flexDirection: 'column',
+    alignItems: 'center',
+    [mq[0]]: {
+      width: '85%',
+    },
+    [mq[1]]: {
+      width: '100%',
+    },
+  })
+);
+
+const Header = styled(FlexBox)(
+  css({
+    my: '4',
+    height: '7',
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    [mq[2]]: {
+      my: '2',
+      height: '6',
+    },
+  })
+);
+
+const PokemonName = styled(FlexBox)(
+  css({
+    mx: 'auto',
+    fontSize: '7',
+    fontWeight: 'bold',
+    color: 'white',
+    [mq[2]]: {
+      fontSize: '5',
+    },
+  })
+);
+
+const BackButton = styled(Button)(
+  css({
+    borderRadius: 'circle',
+    fontSize: 4,
+    color: 'green',
+    bg: 'white',
+    width: '6',
+    height: '6',
+    ml: '5',
+    justifySelf: 'flex-start',
+    [mq[2]]: {
+      ml: '3',
+      fontSize: 3,
+      height: '5',
+      width: '5',
+    },
+  })
+);
+
+const DetailCard = styled(FlexBox)(
+  css({
+    flexDirection: 'column',
+    width: '60%',
+    height: 'auto',
+    bg: 'white',
+    borderRadius: 'normal',
+    mb: '4',
+    [mq[0]]: {
+      width: '70%',
+    },
+    [mq[1]]: {
+      width: '80%',
+    },
+    [mq[2]]: {
+      width: '95%',
+    },
+  })
+);
+
+const Type = styled(FlexBox)(
+  css({
+    textTransform: 'uppercase',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 'normal',
+    border: '1px solid',
+    fontSize: 0,
+    marginRight: '10px',
+    height: '22px',
+    width: 'auto',
+    padding: '0px 5px',
+  })
+);
+
+const StatNameContainer = styled(FlexBox)(
+  css({
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    ml: 'auto',
+  })
+);
+
+const StatBarsContainer = styled(FlexBox)(
+  css({
+    flexDirection: 'column',
+    width: '255px',
+    justifyContent: 'space-between',
+    mx: '4',
+    [mq[2]]: {
+      width: '130px',
+      mx: '3',
+    },
+  })
+);
+
+const StatBar = styled(FlexBox)(
+  css({
+    bg: 'lightGreen',
+    width: '100%',
+    borderRadius: 'normal',
+  })
+);
+
+const StatBarFilling = styled(FlexBox)(
+  css({
+    pl: '1',
+    color: 'white',
+    bg: 'green',
+    borderRadius: 'normal',
+  })
+);
+
+const SectionSeperator = styled(FlexBox)(
+  css({
+    bg: 'green',
+    color: 'white',
+    mx: '4',
+    mt: '3',
+    pl: '3',
+    py: '2',
+    alignItems: 'center',
+    borderRadius: 'normal',
+    [mq[2]]: {
+      mx: '3',
+    },
+  })
+);
+
+const DescriptionContainer = styled(FlexBox)(
+  css({
+    flexDirection: 'column',
+    mx: '5',
+    my: '3',
+    [mq[2]]: {
+      mx: '4',
+    },
+  })
+);
+
+const ProfileContainer = styled(FlexBox)(
+  css({
+    mx: '5',
+    my: '3',
+    [mq[2]]: {
+      mx: '4',
+    },
+  })
+);
+
+const ProfileItem = styled(FlexBox)(
+  css({
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    width: '25%',
+  })
+);
+
 const PokemonDetail = ({ match }) => {
   const leftArrowIcon = <FontAwesomeIcon icon={faArrowLeft} />;
   const [pokemon, setPokemon] = useState({
@@ -18,216 +201,47 @@ const PokemonDetail = ({ match }) => {
     stats: [],
   });
 
-  const breakpoints = [1150, 950, 850];
-  const mq = breakpoints.map(bp => `@media (max-width: ${bp}px)`);
-
-  const id = pokemon.id;
-  const name = pokemon.name;
-  const hp = pokemon.stats.hp;
-  const speed = pokemon.stats.speed;
-  const attack = pokemon.stats.attack;
-  const defense = pokemon.stats.defense;
-  const specialAttack = pokemon.stats['special-attack'];
-  const specialDefense = pokemon.stats['special-defense'];
+  const {
+    id,
+    name,
+    stats: {
+      hp = 0,
+      speed = 0,
+      attack = 0,
+      defense = 0,
+      'special-attack': specialAttack = 0,
+      'special-defense': specialDefense = 0,
+    } = {},
+  } = pokemon;
 
   const maxStatMultiplier = 100 / 255;
 
-  const hpPercent = hp * maxStatMultiplier;
-  const speedPercent = speed * maxStatMultiplier;
-  const attackPercent = attack * maxStatMultiplier;
-  const defensePercent = defense * maxStatMultiplier;
-  const specialAttackPercent = specialAttack * maxStatMultiplier;
-  const specialDefensePercent = specialDefense * maxStatMultiplier;
+  const {
+    hpPercent,
+    speedPercent,
+    attackPercent,
+    defensePercent,
+    specialAttackPercent,
+    specialDefensePercent,
+  } = useMemo(
+    () => ({
+      hpPercent: hp * maxStatMultiplier,
+      speedPercent: speed * maxStatMultiplier,
+      attackPercent: attack * maxStatMultiplier,
+      defensePercent: defense * maxStatMultiplier,
+      specialAttackPercent: specialAttack * maxStatMultiplier,
+      specialDefensePercent: specialDefense * maxStatMultiplier,
+    }),
+    [hp, speed, attack, defense, specialAttack, specialDefense]
+  );
 
   useEffect(() => {
     const fetchPokemon = async () => {
-      const res = await Axios.get(
-        // eslint-disable-next-line react/prop-types
-        `/api/v1/pokemon/${match.params.id}`
-      );
+      const res = await Axios.get(`/api/v1/pokemon/${match.params.id}`);
       setPokemon(res.data);
     };
     fetchPokemon();
-  }, []);
-
-  const DetailContainer = styled(FlexBox)(
-    css({
-      bg: 'green',
-      height: '100vh',
-      width: '65%',
-      flexDirection: 'column',
-      alignItems: 'center',
-      [mq[0]]: {
-        width: '85%',
-      },
-      [mq[1]]: {
-        width: '100%',
-      },
-    })
-  );
-
-  const Header = styled(FlexBox)(
-    css({
-      my: '4',
-      height: '7',
-      width: '100%',
-      alignItems: 'center',
-      justifyContent: 'center',
-      [mq[2]]: {
-        my: '2',
-        height: '6',
-      },
-    })
-  );
-
-  const PokemonName = styled(FlexBox)(
-    css({
-      mx: 'auto',
-      fontSize: '7',
-      fontWeight: 'bold',
-      color: 'white',
-      [mq[2]]: {
-        fontSize: '5',
-      },
-    })
-  );
-
-  const BackButton = styled(Button)(
-    css({
-      borderRadius: 'circle',
-      fontSize: 4,
-      color: 'green',
-      bg: 'white',
-      width: '6',
-      height: '6',
-      ml: '5',
-      justifySelf: 'flex-start',
-      [mq[2]]: {
-        ml: '3',
-        fontSize: 3,
-        height: '5',
-        width: '5',
-      },
-    })
-  );
-
-  const DetailCard = styled(FlexBox)(
-    css({
-      flexDirection: 'column',
-      width: '60%',
-      height: 'auto',
-      bg: 'white',
-      borderRadius: 'normal',
-      mb: '4',
-      [mq[0]]: {
-        width: '70%',
-      },
-      [mq[1]]: {
-        width: '80%',
-      },
-      [mq[2]]: {
-        width: '95%',
-      },
-    })
-  );
-
-  const Type = styled(FlexBox)(
-    css({
-      textTransform: 'uppercase',
-      justifyContent: 'center',
-      alignItems: 'center',
-      borderRadius: 'normal',
-      border: '1px solid',
-      fontSize: 0,
-      marginRight: '10px',
-      height: '22px',
-      width: 'auto',
-      padding: '0px 5px',
-    })
-  );
-
-  const StatNameContainer = styled(FlexBox)(
-    css({
-      flexDirection: 'column',
-      justifyContent: 'space-between',
-      ml: 'auto',
-    })
-  );
-
-  const StatBarsContainer = styled(FlexBox)(
-    css({
-      flexDirection: 'column',
-      width: '255px',
-      justifyContent: 'space-between',
-      mx: '4',
-      [mq[2]]: {
-        width: '130px',
-        mx: '3',
-      },
-    })
-  );
-
-  const StatBar = styled(FlexBox)(
-    css({
-      bg: 'lightGreen',
-      width: '100%',
-      borderRadius: 'normal',
-    })
-  );
-
-  const StatBarFilling = styled(FlexBox)(
-    css({
-      pl: '1',
-      color: 'white',
-      bg: 'green',
-      borderRadius: 'normal',
-    })
-  );
-
-  const SectionSeperator = styled(FlexBox)(
-    css({
-      bg: 'green',
-      color: 'white',
-      mx: '4',
-      mt: '3',
-      pl: '3',
-      py: '2',
-      alignItems: 'center',
-      borderRadius: 'normal',
-      [mq[2]]: {
-        mx: '3',
-      },
-    })
-  );
-
-  const DescriptionContainer = styled(FlexBox)(
-    css({
-      flexDirection: 'column',
-      mx: '5',
-      my: '3',
-      [mq[2]]: {
-        mx: '4',
-      },
-    })
-  );
-
-  const ProfileContainer = styled(FlexBox)(
-    css({
-      mx: '5',
-      my: '3',
-      [mq[2]]: {
-        mx: '4',
-      },
-    })
-  );
-
-  const ProfileItem = styled(FlexBox)(
-    css({
-      flexDirection: 'column',
-      justifyContent: 'space-between',
-      width: '25%',
-    })
-  );
+  }, [match.params.id]);
 
   return (
     <FlexBox justifyContent="center">
@@ -338,6 +352,14 @@ const PokemonDetail = ({ match }) => {
       </DetailContainer>
     </FlexBox>
   );
+};
+
+PokemonDetail.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
 };
 
 export default PokemonDetail;


### PR DESCRIPTION
## Summary
- refactor `PokemonCard` with prop types and memoization
- clean up `PokemonProvider` props handling
- optimize `AuthContext` with callbacks and memoized context value
- move styled components outside `Header`, `Footer`, and `PokemonDetail`
- compute pokemon detail stats with `useMemo`

## Testing
- `yarn lint` *(fails: ESLint couldn't find a configuration file)*
- `yarn test:ci` *(fails: 7 snapshot tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840f393cec08325a8eab23fbf0db683